### PR TITLE
Make Time friendly to Ractor

### DIFF
--- a/lib/time.rb
+++ b/lib/time.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# shareable_constant_value: literal
 
 require 'date'
 

--- a/test/test_time.rb
+++ b/test/test_time.rb
@@ -62,6 +62,13 @@ class TestTimeExtension < Test::Unit::TestCase # :nodoc:
     assert_equal(true, t.utc?)
   end
 
+  if defined?(Ractor)
+    def test_rfc2822_ractor
+      actual = Ractor.new { Time.rfc2822("Fri, 21 Nov 1997 09:55:06 -0600") }.take
+      assert_equal(Time.utc(1997, 11, 21, 9, 55, 6) + 6 * 3600, actual)
+    end
+  end
+
   def test_encode_rfc2822
     t = Time.utc(1)
     assert_equal("Mon, 01 Jan 0001 00:00:00 -0000", t.rfc2822)


### PR DESCRIPTION
(copy of https://github.com/ruby/ruby/pull/4008)

Before this fix,

```ruby
r = Ractor.new do
  Time.rfc2822("Fri, 21 Nov 1997 09:55:06 -0600")
end
Ractor.select(r)
```

fails with:

```
#<Thread:0x00007fe96306b810 run> terminated with exception (report_on_exception is true):
/opt/rubies/3.0.0/lib/ruby/3.0.0/time.rb:515:in `rfc2822': can not access non-shareable objects in constant #<Class:0x00007fe96408dfb8>::MonthValue by non-main ractor. (Ractor::IsolationError)
	from notractor.rb:14:in `block in <main>'
<internal:ractor>:345:in `select': thrown by remote Ractor. (Ractor::RemoteError)
	from notractor.rb:16:in `<main>'
/opt/rubies/3.0.0/lib/ruby/3.0.0/time.rb:515:in `rfc2822': can not access non-shareable objects in constant #<Class:0x00007fe96408dfb8>::MonthValue by non-main ractor. (Ractor::IsolationError)
	from notractor.rb:14:in `block in <main>'
```

@nobu @akr 