### PR TITLE
Do not redefine Time#xmlschema if it already exists

### DIFF
--- a/lib/time.rb
+++ b/lib/time.rb
@@ -695,35 +695,36 @@ class Time
     getutc.strftime('%a, %d %b %Y %T GMT')
   end
 
-  #
-  # Returns a string which represents the time as a dateTime defined by XML
-  # Schema:
-  #
-  #   CCYY-MM-DDThh:mm:ssTZD
-  #   CCYY-MM-DDThh:mm:ss.sssTZD
-  #
-  # where TZD is Z or [+-]hh:mm.
-  #
-  # If self is a UTC time, Z is used as TZD.  [+-]hh:mm is used otherwise.
-  #
-  # +fraction_digits+ specifies a number of digits to use for fractional
-  # seconds.  Its default value is 0.
-  #
-  #     require 'time'
-  #
-  #     t = Time.now
-  #     t.iso8601  # => "2011-10-05T22:26:12-04:00"
-  #
-  # You must require 'time' to use this method.
-  #
-  def xmlschema(fraction_digits=0)
-    fraction_digits = fraction_digits.to_i
-    s = strftime("%FT%T")
-    if fraction_digits > 0
-      s << strftime(".%#{fraction_digits}N")
+  unless method_defined?(:xmlschema)
+    #
+    # Returns a string which represents the time as a dateTime defined by XML
+    # Schema:
+    #
+    #   CCYY-MM-DDThh:mm:ssTZD
+    #   CCYY-MM-DDThh:mm:ss.sssTZD
+    #
+    # where TZD is Z or [+-]hh:mm.
+    #
+    # If self is a UTC time, Z is used as TZD.  [+-]hh:mm is used otherwise.
+    #
+    # +fraction_digits+ specifies a number of digits to use for fractional
+    # seconds.  Its default value is 0.
+    #
+    #     require 'time'
+    #
+    #     t = Time.now
+    #     t.iso8601  # => "2011-10-05T22:26:12-04:00"
+    #
+    # You must require 'time' to use this method.
+    #
+    def xmlschema(fraction_digits=0)
+      fraction_digits = fraction_digits.to_i
+      s = strftime("%FT%T")
+      if fraction_digits > 0
+        s << strftime(".%#{fraction_digits}N")
+      end
+      s << (utc? ? 'Z' : strftime("%:z"))
     end
-    s << (utc? ? 'Z' : strftime("%:z"))
   end
-  alias iso8601 xmlschema
+  alias iso8601 xmlschema unless method_defined?(:iso8601)
 end
-


### PR DESCRIPTION
[[Feature #20707]](https://bugs.ruby-lang.org/issues/20707)

Ref: https://github.com/ruby/ruby/pull/11510

Ruby 3.4 will define this method natively, so the time gem shouldn't redefine it with a slower version.