### PR TITLE
Documentation fixes

### DIFF
--- a/lib/time.rb
+++ b/lib/time.rb
@@ -444,8 +444,8 @@ class Time
     # %X :: Preferred representation for the time alone, no date
     # %y :: Year without a century (00..99)
     # %Y :: Year which may include century, if provided
-    # %z :: Time zone as  hour offset from UTC (e.g. +0900)
-    # %Z :: Time zone name
+    # %z :: \Time zone as hour offset from UTC (e.g. +0900)
+    # %Z :: \Time zone name
     # %% :: Literal "%" character
     # %+ :: date(1) (%a %b %e %H:%M:%S %Z %Y)
     #

--- a/lib/time.rb
+++ b/lib/time.rb
@@ -26,7 +26,7 @@ require 'date'
 
 class Time
 
-  VERSION = "0.4.0"
+  VERSION = "0.4.0"             # :nodoc:
 
   class << Time
 

--- a/lib/time.rb
+++ b/lib/time.rb
@@ -280,7 +280,7 @@ class Time
     #
     # This method **does not** function as a validator.  If the input
     # string does not match valid formats strictly, you may get a
-    # cryptic result.  Should consider to use `Time.strptime` instead
+    # cryptic result.  Should consider to use Time.strptime instead
     # of this method as possible.
     #
     #     require 'time'
@@ -391,7 +391,7 @@ class Time
     # heuristic to detect the format of the input string, you provide
     # a second argument that describes the format of the string.
     #
-    # Raises `ArgumentError` if the date or format is invalid.
+    # Raises ArgumentError if the date or format is invalid.
     #
     # If a block is given, the year described in +date+ is converted by the
     # block.  For example:


### PR DESCRIPTION
- RDoc does not use backticks
- Escape the word "Time" that does not mean Time class
- nodoc `VERSION`