### PR TITLE
Allow setting a default time zone for Time.parse

### DIFF
--- a/lib/time.rb
+++ b/lib/time.rb
@@ -369,6 +369,9 @@ class Time
     # If the extracted time zone abbreviation does not match any of them,
     # it is ignored and the given time is regarded as a local time.
     #
+    # A +zone+ argument can be provided to specify the zone for the given
+    # +date+, if the +date+ does not include a time zone or offset.
+    #
     # ArgumentError is raised if Date._parse cannot extract information from
     # +date+ or if the Time class cannot represent specified date.
     #
@@ -382,12 +385,12 @@ class Time
     #
     # You must require 'time' to use this method.
     #
-    def parse(date, now=self.now)
+    def parse(date, now=self.now, zone: nil)
       comp = !block_given?
       d = Date._parse(date, comp)
       year = d[:year]
       year = yield(year) if year && !comp
-      make_time(date, year, d[:yday], d[:mon], d[:mday], d[:hour], d[:min], d[:sec], d[:sec_fraction], d[:zone], now)
+      make_time(date, year, d[:yday], d[:mon], d[:mday], d[:hour], d[:min], d[:sec], d[:sec_fraction], d[:zone] || zone, now)
     end
 
     #

--- a/test/test_time.rb
+++ b/test/test_time.rb
@@ -370,6 +370,15 @@ class TestTimeExtension < Test::Unit::TestCase # :nodoc:
     assert_equal(t, Time.parse("1200-02-15 BC 14:13:20-00:00:00"))
   end
 
+  def test_parse_custom_offset
+    t = Time.at(-100000000000).utc
+    assert_equal(t, Time.parse("1200-02-15 BC 14:13:20", zone: "UTC"))
+    assert_equal(t, Time.parse("1200-02-15 BC 15:13:20", zone: "+01:00").utc)
+
+    assert_equal(t, Time.parse("1200-02-15 BC 15:13:20+01:00", zone: "UTC").utc)
+    assert_equal(t, Time.parse("1200-02-15 BC 15:13:20+01:00", zone: "+02:00").utc)
+  end
+
   def test_parse_leap_second
     t = Time.utc(1998,12,31,23,59,59)
     assert_equal(t, Time.parse("Thu Dec 31 23:59:59 UTC 1998"))


### PR DESCRIPTION
This is to allow for easier conversion of DateTime.parse code to Time.parse. DateTime.parse will assume UTC for parsed times without a time zone or offset, while Time will assume local time. This allows using `zone: "UTC"` to match the DateTime.parse behavior.

Ideally, it would have pulled the timezone from the `now` argument, but I believe that backwards incompatibility from doing that now is too great.

You can work around this now by appending " UTC" to the parsed string, as that is ignored if the string actually has a timezone or offset, but that doesn't seem like a clean approach.