### PR TITLE
Add Gemfile.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+Gemfile.lock


### PR DESCRIPTION
## Summary

Ignore `Gemfile.lock` in the repository.

`bundle install` generates `Gemfile.lock`, but the repository does not track it. Ignoring the generated lockfile keeps the working tree clean after the standard development setup.

## Before

```console
$ bundle install
$ git status

Untracked files:
  Gemfile.lock
```

## After

```console
$ bundle install
$ git status

nothing to commit, working tree clean
```