### PR TITLE
Fix `Time.xmlschema` handling leading and trailing whitespaces

### DIFF
--- a/lib/time.rb
+++ b/lib/time.rb
@@ -670,7 +670,7 @@ class Time
     if RUBY_VERSION >= "3.2"
       def _xmlschema(pattern, time) # :nodoc:
         if pattern.match?(time)
-          new(time)
+          new(time.strip)
         else
           raise ArgumentError.new("invalid xmlschema format: #{time.inspect}")
         end

--- a/test/test_time.rb
+++ b/test/test_time.rb
@@ -245,6 +245,16 @@ class TestTimeExtension < Test::Unit::TestCase # :nodoc:
     assert_equal("-10000-01-01T00:00:00Z", Time.utc(-10000).__send__(method))
   end
 
+  def subtest_xmlschema_whitespaces(method)
+    t = Time.utc(1985, 4, 12, 23, 20, 50, 520000)
+    s = "  \t  1985-04-12T23:20:50.52Z"
+    assert_equal(t, Time.__send__(method, s))
+
+    t = Time.utc(1985, 4, 12, 23, 20, 50, 520000)
+    s = "1985-04-12T23:20:50.52Z  \t "
+    assert_equal(t, Time.__send__(method, s))
+  end
+
   def test_completion
     now = Time.local(2001,11,29,21,26,35)
     assert_equal(Time.local( 2001,11,29,21,12),


### PR DESCRIPTION
Followup: https://github.com/ruby/time/pull/66

This reduce the gain to only ~3.8x instead of ~4x, but still worth it.

```
2026-07-20 08:37:09.66407 +0200
2026-07-20 08:37:09.66407 +0200
ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
           xmlschema    68.139k i/100ms
            Time.new   510.172k i/100ms
                 opt   239.558k i/100ms
Calculating -------------------------------------
           xmlschema    667.174k (± 1.4%) i/s    (1.50 μs/i) -      3.339M in   5.004405s
            Time.new      5.539M (± 1.3%) i/s  (180.53 ns/i) -     28.059M in   5.065670s
                 opt      2.538M (± 0.7%) i/s  (394.01 ns/i) -     12.697M in   5.002588s

Comparison:
xmlschema:   667174.4 i/s
 Time.new:  5539140.9 i/s - 8.30x  faster
      opt:  2538001.1 i/s - 3.80x  faster
```
