### PR TITLE
Add RDoc task for local documentation coverage checks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ group :development do
   gem "rake", "~> 13.2"
   gem "test-unit"
   gem "test-unit-ruby-core", ">= 1.0.7"
+  gem "rdoc", ">= 6.3"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
+require "rdoc/task"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test/lib"
@@ -7,4 +8,9 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/**/test_*.rb"]
 end
 
-task :default => :test
+RDoc::Task.new do |rdoc|
+  rdoc.main = "README.md"
+  rdoc.rdoc_files.include("README.md", "lib/**/*.rb")
+end
+
+task default: :test


### PR DESCRIPTION
## Summary

Add an `RDoc::Task` and the `rdoc` development dependency so contributors can run the documentation coverage check locally:

```sh
bundle exec rake rdoc:coverage
```
This exposes the RDoc documentation coverage task locally. It can help contributors identify documentation coverage issues before changes are synchronized into ruby/ruby.

## Changes

- add rdoc as a development dependency
- register RDoc::Task
- expose bundle exec rake rdoc:coverage

## Example

```text
$ bundle exec rake rdoc:coverage

100.00% documented
```

##  Scope

This change only exposes the existing RDoc task locally.

It does **not:**

- change the default Rake tasks
- add or modify CI
- introduce any new contributor requirements