### PR TITLE
Handle case insensitive match for Time.{iso8601,xmlschema,rfc3339}

### DIFF
--- a/lib/time.rb
+++ b/lib/time.rb
@@ -670,7 +670,9 @@ class Time
     if RUBY_VERSION >= "3.2"
       def _xmlschema(pattern, time) # :nodoc:
         if pattern.match?(time)
-          new(time.strip)
+          time = time.strip
+          time.upcase!
+          new(time)
         else
           raise ArgumentError.new("invalid xmlschema format: #{time.inspect}")
         end

--- a/test/test_time.rb
+++ b/test/test_time.rb
@@ -162,6 +162,8 @@ class TestTimeExtension < Test::Unit::TestCase # :nodoc:
                  Time.__send__(method, "2000-03-04T23:00:00+03:00"))
     assert_equal(Time.utc(2000, 3, 4, 20, 0, 0),
                  Time.__send__(method, "2000-03-04T20:00:00Z"))
+    assert_equal(Time.utc(2000, 3, 4, 20, 0, 0),
+                 Time.__send__(method, "2000-03-04t20:00:00z"))
     assert_equal(Time.utc(2000, 1, 16, 12, 0, 0),
                  Time.__send__(method, "2000-01-16T12:00:00Z"))
     assert_equal(Time.utc(1999, 12, 31, 23, 0, 0),


### PR DESCRIPTION
The T and Z in the regular expressions are case insensitive, but Time.new on Ruby 3.2+ does not support the lowercase versions. Arguably, lower case t and z shouldn't be allowed, but they were historically supported. Time.rfc3339 is a new method, so backwards compatibility is not technically necessary, but the ActiveSupport Time.rfc3339 method supports the lower case versions.

The optimization in b8c50d236ccd20f8d6064d3c03b9f388af3dd1d1 broke backwards compatibility for lower case t and z, since it started calling Time.new.

While I don't necessarily have a problem with breaking backwards compatibility in order to improve standards conformance (depending on the case), I think the decision should be deliberate and not accidental due to an optimization.

The fix is trivial, and doesn't cause an additional allocation, since strip already returns a fresh string.