### PR TITLE
Fix wrong result in Time.rfc2822 documentation

### DIFF
--- a/lib/time.rb
+++ b/lib/time.rb
@@ -510,7 +510,7 @@ class Time
     #     require 'time'
     #
     #     Time.rfc2822("Wed, 05 Oct 2011 22:26:12 -0400")
-    #     #=> 2010-10-05 22:26:12 -0400
+    #     #=> 2011-10-05 22:26:12 -0400
     #
     # You must require 'time' to use this method.
     #


### PR DESCRIPTION
The sample code and its result in the Time.rfc2822 documentation appear to be inconsistent.
I've rewritten it to match the actual output when run against the latest HEAD (95ab5fafe77bc7f78a0743fa75d52d95336913d2).
Environment: ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [arm64-darwin24]